### PR TITLE
Display @ before mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 > diaspora-style @mention plugin for [markdown-it](https://github.com/markdown-it/markdown-it) markdown parser.
 
-`@{user@pod.tld}` => `<a href="/people/1337" class="mention">User Name</a>`
+`@{user@pod.tld}` => `@<a href="/people/1337" class="mention">User Name</a>`
 
-`@{User Name; user@pod.tld}` => `<a href="/people/1337" class="mention">User Name</a>`
+`@{User Name; user@pod.tld}` => `@<a href="/people/1337" class="mention">User Name</a>`
 
 ## Install
 
@@ -41,9 +41,9 @@ var md = require("markdown-it")()
               currentUserId: 1337
             });
 
-md.render("@{User Name; user@pod.tld}"); // => "<a href='/people/1337' class='mention'>User Name</a>"
-md.render("@{user@pod.tld}"); // => "<a href='/people/1337' class='mention'>Alice Awesome</a>"
-md.render("@{Foo Bar; foo@bar.baz}"); // => "<a href='/my/awesome/url' class='mention hovercardable'>Foo Bar</a>"
+md.render("@{User Name; user@pod.tld}"); // => "@<a href='/people/1337' class='mention'>User Name</a>"
+md.render("@{user@pod.tld}"); // => "@<a href='/people/1337' class='mention'>Alice Awesome</a>"
+md.render("@{Foo Bar; foo@bar.baz}"); // => "@<a href='/my/awesome/url' class='mention hovercardable'>Foo Bar</a>"
 ```
 
 _Differences in the browser._ If you load the script directly into the page, without a

--- a/index.js
+++ b/index.js
@@ -96,6 +96,11 @@ class MentionPlugin {
         tokens.push(token);
       }
 
+      token = new state.Token("text", "", 0);
+      token.content = "@";
+      token.level = level;
+      tokens.push(token);
+
       const person = this.findPersonById(diasporaId);
 
       if (person) {

--- a/test/fixtures/mention/base.txt
+++ b/test/fixtures/mention/base.txt
@@ -2,13 +2,13 @@ creates links for known users by guid
 .
 @{User Name; user@pod.tld}
 .
-<p><a href="/people/1337" class="mention">User Name</a></p>
+<p>@<a href="/people/1337" class="mention">User Name</a></p>
 .
 
 .
 @{user@pod.tld}
 .
-<p><a href="/people/1337" class="mention">User Name</a></p>
+<p>@<a href="/people/1337" class="mention">User Name</a></p>
 .
 
 
@@ -17,13 +17,13 @@ creates links for known users by url
 .
 @{User Foo; foo@bar.baz}
 .
-<p><a href="/my/awesome/url" class="mention hovercardable">User Foo</a></p>
+<p>@<a href="/my/awesome/url" class="mention hovercardable">User Foo</a></p>
 .
 
 .
 @{foo@bar.baz}
 .
-<p><a href="/my/awesome/url" class="mention hovercardable">User Foo</a></p>
+<p>@<a href="/my/awesome/url" class="mention hovercardable">User Foo</a></p>
 .
 
 
@@ -32,7 +32,7 @@ uses the name given in mention itself if it exists
 .
 @{Alice Awesome; user@pod.tld}
 .
-<p><a href="/people/1337" class="mention">Alice Awesome</a></p>
+<p>@<a href="/people/1337" class="mention">Alice Awesome</a></p>
 .
 
 
@@ -41,7 +41,7 @@ uses the name for unknown users if it exists
 .
 @{Mysterious User; unknown@pod.tld}
 .
-<p>Mysterious User</p>
+<p>@Mysterious User</p>
 .
 
 
@@ -50,7 +50,7 @@ uses the diaspora id for unknown users with no name given
 .
 @{unknown@pod.tld}
 .
-<p>unknown@pod.tld</p>
+<p>@unknown@pod.tld</p>
 .
 
 
@@ -59,19 +59,19 @@ accepts multiple mentions per line
 .
 I mention @{User Name; user@pod.tld} and @{User Foo; foo@bar.baz} because they are awesome!
 .
-<p>I mention <a href="/people/1337" class="mention">User Name</a> and <a href="/my/awesome/url" class="mention hovercardable">User Foo</a> because they are awesome!</p>
+<p>I mention @<a href="/people/1337" class="mention">User Name</a> and @<a href="/my/awesome/url" class="mention hovercardable">User Foo</a> because they are awesome!</p>
 .
 
 .
 I mention @{user@pod.tld} and @{foo@bar.baz} because they are awesome!
 .
-<p>I mention <a href="/people/1337" class="mention">User Name</a> and <a href="/my/awesome/url" class="mention hovercardable">User Foo</a> because they are awesome!</p>
+<p>I mention @<a href="/people/1337" class="mention">User Name</a> and @<a href="/my/awesome/url" class="mention hovercardable">User Foo</a> because they are awesome!</p>
 .
 
 .
 I mention @{User Name; user@pod.tld} and @{foo@bar.baz} because they are awesome!
 .
-<p>I mention <a href="/people/1337" class="mention">User Name</a> and <a href="/my/awesome/url" class="mention hovercardable">User Foo</a> because they are awesome!</p>
+<p>I mention @<a href="/people/1337" class="mention">User Name</a> and @<a href="/my/awesome/url" class="mention hovercardable">User Foo</a> because they are awesome!</p>
 .
 
 
@@ -80,7 +80,7 @@ allows semicolons in user names
 .
 @{Alice; Awesome; user@pod.tld}
 .
-<p><a href="/people/1337" class="mention">Alice; Awesome</a></p>
+<p>@<a href="/people/1337" class="mention">Alice; Awesome</a></p>
 .
 
 
@@ -278,16 +278,17 @@ removes trailing spaces
 .
 @{User Name; userwithspaces@pod.tld}
 .
-<p><a href="/people/1338" class="mention hovercardable">User Name</a></p>
+<p>@<a href="/people/1338" class="mention hovercardable">User Name</a></p>
 .
 
 .
 @{Name with trailing spaces    ; userwithspaces@pod.tld}
 .
-<p><a href="/people/1338" class="mention hovercardable">Name with trailing spaces</a></p>
+<p>@<a href="/people/1338" class="mention hovercardable">Name with trailing spaces</a></p>
 .
 
 .
 @{userwithspaces@pod.tld}
 .
-<p><a href="/people/1338" class="mention hovercardable">User Name</a></p>
+<p>@<a href="/people/1338" class="mention hovercardable">User Name</a></p>
+.

--- a/test/fixtures/mention/nohtml.txt
+++ b/test/fixtures/mention/nohtml.txt
@@ -2,17 +2,17 @@ escapes html entities
 .
 @{<script>alert(0)</script>; unknown@pod.tld}
 .
-<p>&lt;script&gt;alert(0)&lt;/script&gt;</p>
+<p>@&lt;script&gt;alert(0)&lt;/script&gt;</p>
 .
 
 .
 @{<script>alert(0)</script>; evil@pod.tld}
 .
-<p><a href="/people/666" class="mention hovercardable">&lt;script&gt;alert(0)&lt;/script&gt;</a></p>
+<p>@<a href="/people/666" class="mention hovercardable">&lt;script&gt;alert(0)&lt;/script&gt;</a></p>
 .
 
 .
 @{evil@pod.tld}
 .
-<p><a href="/people/666" class="mention hovercardable">&lt;script&gt;alert(0)&lt;/script&gt;</a></p>
+<p>@<a href="/people/666" class="mention hovercardable">&lt;script&gt;alert(0)&lt;/script&gt;</a></p>
 .


### PR DESCRIPTION
This adds the @ before the mentions link as suggested in diaspora/diaspora#7269.

After this is released I can add the same to the diaspora backend.

(also fixed the last test in base.txt)